### PR TITLE
Fix PHP 8 deprecated notice with ConnectionInterface

### DIFF
--- a/src/Elasticsearch/ClientBuilder.php
+++ b/src/Elasticsearch/ClientBuilder.php
@@ -587,7 +587,7 @@ class ClientBuilder
         }
 
         if (is_null($this->transport)) {
-            $this->transport = new Transport($this->retries, $this->sniffOnStart, $this->connectionPool, $this->logger);
+            $this->transport = new Transport($this->retries, $this->connectionPool, $this->logger, (bool)$this->sniffOnStart);
         }
     }
 

--- a/src/Elasticsearch/Connections/ConnectionInterface.php
+++ b/src/Elasticsearch/Connections/ConnectionInterface.php
@@ -95,5 +95,5 @@ interface ConnectionInterface
      * @param \Elasticsearch\Transport $transport
      * @return mixed
      */
-    public function performRequest($method, $uri, $params = null, $body = null, $options = [], Transport $transport);
+    public function performRequest($method, $uri, $params = null, $body = null, $options = [], Transport $transport = null);
 }

--- a/src/Elasticsearch/Transport.php
+++ b/src/Elasticsearch/Transport.php
@@ -48,7 +48,7 @@ class Transport
      * @param ConnectionPool\AbstractConnectionPool $connectionPool
      * @param \Psr\Log\LoggerInterface $log    Monolog logger object
      */
-    public function __construct($retries, $sniffOnStart = false, AbstractConnectionPool $connectionPool, LoggerInterface $log)
+    public function __construct($retries, AbstractConnectionPool $connectionPool, LoggerInterface $log, bool $sniffOnStart = false)
     {
         $this->log            = $log;
         $this->connectionPool = $connectionPool;

--- a/src/Elasticsearch/Transport.php
+++ b/src/Elasticsearch/Transport.php
@@ -44,9 +44,9 @@ class Transport
      * underlying cluster connections
      *
      * @param $retries
-     * @param bool $sniffOnStart
      * @param ConnectionPool\AbstractConnectionPool $connectionPool
      * @param \Psr\Log\LoggerInterface $log    Monolog logger object
+     * @param bool $sniffOnStart
      */
     public function __construct($retries, AbstractConnectionPool $connectionPool, LoggerInterface $log, bool $sniffOnStart = false)
     {


### PR DESCRIPTION
This partially backports https://github.com/elastic/elasticsearch-php/commit/358586fe3ac92d0326942b7f01b0c2e341abe29f to the 5.x branch to fix the following deprecated notices from php 8
>  Sep 15 20:43:26 elijahfounded-cloud-dev-vm php[8734]: Deprecated: Required parameter $transport follows optional parameter $params in ....current/vendor/elasticsearch/elasticsearch/src/Elasticsearch/Connections/ConnectionInterface.php on line 98

Also fixed
> Sep 15 20:43:26 elijahfounded-cloud-dev-vm bcdeploy[18992]: PHP Deprecated:  Required parameter $connectionPool follows optional parameter $sniffOnStart in ....current/vendor/elasticsearch/elasticsearch/src/Elasticsearch/Transport.php on line 51


ping @TomA-R @lord2800 